### PR TITLE
Fixing PDF PATHS

### DIFF
--- a/proc/logaccess_loadlogs.py
+++ b/proc/logaccess_loadlogs.py
@@ -100,10 +100,13 @@ for logdir in LOG_DIRS:
                     dat = data['%t'][8:12]+month
                     
                     if validate_date(dat):
-                        analytics.update({"site":COLLECTION_DOMAIN}, {"$inc":{'dwn':1,'dwn_'+dat:1,'total':1,"dat_"+dat:1}},True)
                         pdfid = data['%r'][4:data['%r'].find('.pdf')]
+                        #cleaning // and %0D/
+                        pdfid = pdfid.replace("//","/")
+                        pdfid = pdfid.replace("%0D/","")
                         if validate_pdf(pdfid):
                             pdf_spl = pdfid.split("/")
+                            analytics.update({"site":COLLECTION_DOMAIN}, {"$inc":{'dwn':1,'dwn_'+dat:1,'total':1,"dat_"+dat:1}},True)
                             analytics.update({"dwn":pdf_spl[2]}, {"$inc":{'total':1,"dwn_"+dat:1}},True)
                             analytics.update({"dwn":pdfid}, {"$set":{'page':'pdf_download','acron':pdf_spl[2]},"$inc":{'total':1,"dwn_"+dat:1}},True)
                         else:


### PR DESCRIPTION
A ruge among of requests were with some special chars that represents empty chars.

66.249.72.201 - - [11/Jun/2011:00:01:43 -0300] "GET /pdf/%0D/bjid/v5n6/v5n6a03.pdf HTTP/1.1" 200 3778726 "-" "SAMSUNG-SGH-E250/1.0 Profile/MIDP-2.0 Configuration/CLDC-1.1 UP.Browser/6.2.3.3.c.1.101 (GUI) MMP/2.0 (compatible; Googlebot-Mobile/2.1; 

The response was ok, but once the id for the accesslog is the filepath, these chars most be removed before counting access into mongodb.
