### PR TITLE
Include HTTP status code check

### DIFF
--- a/logger/accesschecker.py
+++ b/logger/accesschecker.py
@@ -226,7 +226,11 @@ class AccessChecker(object):
         data['day'] = data['iso_date'][8:10]
         data['month'] = data['iso_date'][5:7]
         data['year'] = data['iso_date'][0:4]
+        data['http_code'] = parsed_line['%>s']
 
+        if not data['http_code'] or data['http_code'] not in ['200', '304']:
+            return None
+ 
         if not data['access_type']:
             return None
 

--- a/logger/inspector.py
+++ b/logger/inspector.py
@@ -56,19 +56,6 @@ def _config_logging(logging_level='INFO', logging_file=None):
     logger.addHandler(hl)
 
 
-def collections():
-    collections = {}
-    try:
-        collections = am_client.collections()
-        return {i.acronym2letters: i for i in collections}
-    except:
-        logger.error('Fail to retrieve collections')
-    return {}
-
-
-COLLECTIONS = collections()
-
-
 class Inspector(object):
 
     def __init__(self, filename):
@@ -77,10 +64,16 @@ class Inspector(object):
         self._file = filename
         self._filename = filename.split('/')[-1]
         self._parsed_fn = REGEX_FILENAME.match(self._filename)
+        self.collections = self.get_collections()
 
-    @property
-    def collections(self):
-        return COLLECTIONS
+    def get_collections(self):
+        collections = {}
+        try:
+            collections = am_client.collections()
+            return {i.acronym2letters: i for i in collections}
+        except:
+            logger.error('Fail to retrieve collections')
+        return {}
 
     def _is_valid_filename(self):
         if not self._parsed_fn:

--- a/tests/test_accesseschecker.py
+++ b/tests/test_accesseschecker.py
@@ -676,6 +676,7 @@ class AccessCheckerTests(MockerTestCase):
                             'script': 'sci_arttext'
                         },
                         'day': '30',
+                        'http_code': '200',
                         'original_agent': 'Mozilla/5.0 (compatible; MSIE 10.0; Windows NT 6.1; Trident/6.0)',
                         'original_date': '[30/May/2013:00:01:01 -0300]',
                         'script': 'sci_arttext',
@@ -706,6 +707,7 @@ class AccessCheckerTests(MockerTestCase):
                         'year': '2013',
                         'query_string': None,
                         'day': '30',
+                        'http_code': '200',
                         'original_agent': 'Mozilla/5.0 (compatible; MSIE 10.0; Windows NT 6.1; Trident/6.0)',
                         'original_date': '[30/May/2013:00:01:01 -0300]',
                         'script': '',
@@ -736,6 +738,7 @@ class AccessCheckerTests(MockerTestCase):
                         'year': '2013',
                         'query_string': None,
                         'day': '30',
+                        'http_code': '200',
                         'original_agent': 'Mozilla/5.0 (compatible; MSIE 10.0; Windows NT 6.1; Trident/6.0)',
                         'original_date': '[30/May/2013:00:01:01 -0300]',
                         'script': '',
@@ -811,6 +814,7 @@ class AccessCheckerTests(MockerTestCase):
                         'year': '2013',
                         'day': '30',
                         'month': '05',
+                        'http_code': '200',
                         'original_agent': 'Mozilla/5.0 (compatible; MSIE 10.0; Windows NT 6.1; Trident/6.0)',
                         'original_date': '[30/May/2013:00:01:01 -0300]',
                         'query_string': None,
@@ -833,7 +837,7 @@ class AccessCheckerTests(MockerTestCase):
 
         ac = AccessChecker(collection='scl')
 
-        line = '201.14.120.2 - - [30/May/2013:00:01:01 -0300] "GET http://www.scielo.br/pdf/bjmbr/v14n4/03.pdf HTTP/1.1" 206 4608 "-" "Mozilla/5.0 (compatible; MSIE 10.0; Windows NT 6.1; Trident/6.0)"'
+        line = '201.14.120.2 - - [30/May/2013:00:01:01 -0300] "GET http://www.scielo.br/pdf/bjmbr/v14n4/03.pdf HTTP/1.1" 200 4608 "-" "Mozilla/5.0 (compatible; MSIE 10.0; Windows NT 6.1; Trident/6.0)"'
 
         expected = {
                         'ip': '201.14.120.2',
@@ -844,6 +848,7 @@ class AccessCheckerTests(MockerTestCase):
                         'year': '2013',
                         'day': '30',
                         'month': '05',
+                        'http_code': '200',
                         'original_agent': 'Mozilla/5.0 (compatible; MSIE 10.0; Windows NT 6.1; Trident/6.0)',
                         'original_date': '[30/May/2013:00:01:01 -0300]',
                         'query_string': None,
@@ -865,7 +870,7 @@ class AccessCheckerTests(MockerTestCase):
 
         ac = AccessChecker(collection='scl')
 
-        line = '201.14.120.2 - - [30/May/2013:00:01:01 -0300] "GET https://www.scielo.br/pdf/bjmbr/2018.v51n11/e7704/en HTTP/1.1" 206 4608 "-" "Mozilla/5.0 (compatible; MSIE 10.0; Windows NT 6.1; Trident/6.0)"'
+        line = '201.14.120.2 - - [30/May/2013:00:01:01 -0300] "GET https://www.scielo.br/pdf/bjmbr/2018.v51n11/e7704/en HTTP/1.1" 200 4608 "-" "Mozilla/5.0 (compatible; MSIE 10.0; Windows NT 6.1; Trident/6.0)"'
 
         expected = {
                         'ip': '201.14.120.2',
@@ -876,6 +881,7 @@ class AccessCheckerTests(MockerTestCase):
                         'year': '2013',
                         'day': '30',
                         'month': '05',
+                        'http_code': '200',
                         'original_agent': 'Mozilla/5.0 (compatible; MSIE 10.0; Windows NT 6.1; Trident/6.0)',
                         'original_date': '[30/May/2013:00:01:01 -0300]',
                         'query_string': None,
@@ -897,7 +903,7 @@ class AccessCheckerTests(MockerTestCase):
 
         ac = AccessChecker(collection='scl')
 
-        line = '201.14.120.2 - - [30/May/2013:00:01:01 -0300] "GET /pdf/bjmbr/2018.v51n11/e7704/en HTTP/1.1" 206 4608 "-" "Mozilla/5.0 (compatible; MSIE 10.0; Windows NT 6.1; Trident/6.0)"'
+        line = '201.14.120.2 - - [30/May/2013:00:01:01 -0300] "GET /pdf/bjmbr/2018.v51n11/e7704/en HTTP/1.1" 200 4608 "-" "Mozilla/5.0 (compatible; MSIE 10.0; Windows NT 6.1; Trident/6.0)"'
 
         expected = {
                         'ip': '201.14.120.2',
@@ -908,6 +914,7 @@ class AccessCheckerTests(MockerTestCase):
                         'year': '2013',
                         'day': '30',
                         'month': '05',
+                        'http_code': '200',
                         'original_agent': 'Mozilla/5.0 (compatible; MSIE 10.0; Windows NT 6.1; Trident/6.0)',
                         'original_date': '[30/May/2013:00:01:01 -0300]',
                         'query_string': None,
@@ -947,21 +954,3 @@ class AccessCheckerTests(MockerTestCase):
         line = '177.191.212.233 - - [30/May/2013:00:01:01 -0300] "GET http://www.scielo.br/img/pt/author.gif HTTP/1.1" 304 0 "http://www.scielo.br/scielo.php?script=sci_serial&pid=1415-4757&nrm=iso&rep=&lng=pt" "Mozilla/5.0 (Windows NT 5.1) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/27.0.1453.94 Safari/537.36"'
 
         self.assertEqual(ac.parsed_access(line), None)
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-

--- a/tests/test_accesseschecker.py
+++ b/tests/test_accesseschecker.py
@@ -685,6 +685,23 @@ class AccessCheckerTests(MockerTestCase):
 
         self.assertEqual(ac.parsed_access(line), expected)
 
+    def test_parsed_access_invalid_http_status_code(self):
+        accesschecker = self.mocker.patch(AccessChecker)
+        accesschecker._allowed_collections()
+        self.mocker.result([u'scl', u'arg'])
+        accesschecker._acronym_to_issn_dict()
+        self.mocker.result({u'zool': u'1984-4670', u'bjmbr': u'1414-431X'})
+
+        self.mocker.replay()
+
+        ac = AccessChecker(collection='scl')
+
+        line = '187.19.211.179 - - [30/May/2013:00:01:01 -0300] "GET http://www.scielo.br/scielo.php?pid=S1414-431X2000000300007&script=sci_arttext HTTP/1.1" 404 25084 "-" "Mozilla/5.0 (compatible; MSIE 10.0; Windows NT 6.1; Trident/6.0)"'
+
+        expected = None
+
+        self.assertEqual(ac.parsed_access(line), expected)
+
     def test_parsed_access_valid_html_access_on_new_site(self):
         accesschecker = self.mocker.patch(AccessChecker)
         accesschecker._allowed_collections()

--- a/tests/test_inspector.py
+++ b/tests/test_inspector.py
@@ -1,13 +1,43 @@
 import unittest
 
-from logger import inspector
+from logger.inspector import Inspector
 from mocker import ANY, MockerTestCase
 
+COLLECTIONS = {
+    'br': {
+        "status": "certified",
+        "original_name": "Brasil",
+        "document_count": 392414,
+        "acron": "scl",
+        "domain": "www.scielo.br",
+        "has_analytics": True,
+        "is_active": True,
+        "journal_count": {
+            "deceased": 42,
+            "suspended": 36,
+            "current": 295
+        },
+        "type": "journals",
+        "acron2": "br",
+        "name": {
+            "en": "Brazil",
+            "es": "Brasil",
+            "pt": "Brasil"
+        },
+        "code": "scl"
+    }
+}
 
 class TestInspectorTests(MockerTestCase):
 
     def test_is_valid_filename_node1(self):
-        insp = inspector.Inspector('/var/www/scielo.br/2015-12-30_scielo.br.1.log.gz')
+
+        _insp = self.mocker.patch(Inspector)
+        _insp.get_collections()
+        self.mocker.result(COLLECTIONS)
+        self.mocker.replay()
+
+        insp = Inspector('/var/www/scielo.br/2015-12-30_scielo.br.1.log.gz')
 
         self.assertTrue(insp._is_valid_filename())
         expected = {
@@ -17,7 +47,12 @@ class TestInspectorTests(MockerTestCase):
         self.assertEqual(expected, insp._parsed_fn.groupdict())
 
     def test_is_valid_filename(self):
-        insp = inspector.Inspector('/var/www/scielo.br/2015-12-30_scielo.br.log.gz')
+        _insp = self.mocker.patch(Inspector)
+        _insp.get_collections()
+        self.mocker.result(COLLECTIONS)
+        self.mocker.replay()
+
+        insp = Inspector('/var/www/scielo.br/2015-12-30_scielo.br.log.gz')
 
         self.assertTrue(insp._is_valid_filename())
         expected = {
@@ -27,48 +62,77 @@ class TestInspectorTests(MockerTestCase):
         self.assertEqual(expected, insp._parsed_fn.groupdict())
 
     def test_is_valid_filename_false(self):
-        insp = inspector.Inspector('/var/www/scielo.br/2015-12-30_scilo.br.log.gz')
+        _insp = self.mocker.patch(Inspector)
+        _insp.get_collections()
+        self.mocker.result(COLLECTIONS)
+        self.mocker.replay()
+
+        insp = Inspector('/var/www/scielo.br/2015-12-30_scilo.br.log.gz')
 
         self.assertFalse(insp._is_valid_filename())
 
     def test_is_valid_date_in_filename(self):
-        insp = inspector.Inspector('/var/www/scielo.br/2015-12-30_scielo.br.log.gz')
+        _insp = self.mocker.patch(Inspector)
+        _insp.get_collections()
+        self.mocker.result(COLLECTIONS)
+        self.mocker.replay()
+
+        insp = Inspector('/var/www/scielo.br/2015-12-30_scielo.br.log.gz')
 
         self.assertTrue(insp._is_valid_date())
 
     def test_is_valid_date_in_filename_false(self):
-        insp = inspector.Inspector('/var/www/scielo.br/2015-31-12_scielo.br.log.gz')
+        _insp = self.mocker.patch(Inspector)
+        _insp.get_collections()
+        self.mocker.result(COLLECTIONS)
+        self.mocker.replay()
+
+        insp = Inspector('/var/www/scielo.br/2015-31-12_scielo.br.log.gz')
 
         self.assertFalse(insp._is_valid_date())
 
     def test_is_valid_collection_in_filename(self):
-        _insp = self.mocker.patch(inspector.Inspector)
-        _insp.collections
-        self.mocker.result({'br': None})
+        _insp = self.mocker.patch(Inspector)
+        _insp.get_collections()
+        self.mocker.result(COLLECTIONS)
         self.mocker.replay()
-        insp = inspector.Inspector('/var/www/scielo.br/2015-12-30_scielo.br.log.gz')
+
+        insp = Inspector('/var/www/scielo.br/2015-12-30_scielo.br.log.gz')
         self.assertTrue(insp._is_valid_collection())
 
     def test_is_invalid_collection_in_filename(self):
-        _insp = self.mocker.patch(inspector.Inspector)
-        _insp.collections
-        self.mocker.result({'br': None})
+        _insp = self.mocker.patch(Inspector)
+        _insp.get_collections()
+        self.mocker.result(COLLECTIONS)
         self.mocker.replay()
 
-        insp = inspector.Inspector('/var/www/scielo.br/2015-12-30_scielo.xxx.log.gz')
+        insp = Inspector('/var/www/scielo.br/2015-12-30_scielo.xxx.log.gz')
         self.assertFalse(insp._is_valid_collection())
 
     def test_is_valid_source_directory(self):
-        insp = inspector.Inspector('/var/www/scielo.br/2015-12-30_scielo.br.log.gz')
+        _insp = self.mocker.patch(Inspector)
+        _insp.get_collections()
+        self.mocker.result(COLLECTIONS)
+        self.mocker.replay()
+        insp = Inspector('/var/www/scielo.br/2015-12-30_scielo.br.log.gz')
 
         self.assertTrue(insp._is_valid_source_directory())
 
-    def test_is_valid_source_directory_false(self):
-        insp = inspector.Inspector('/var/www/scielo.br/2015-12-30_sciel.br.log.gz')
+    def test_is_valid_source_directory_false_1(self):
+        _insp = self.mocker.patch(Inspector)
+        _insp.get_collections()
+        self.mocker.result(COLLECTIONS)
+        self.mocker.replay()
+        insp = Inspector('/var/www/scielo.br/2015-12-30_sciel.br.log.gz')
 
         self.assertFalse(insp._is_valid_source_directory())
 
-    def test_is_valid_source_directory_false(self):
-        insp = inspector.Inspector('/var/www/scielo.pepsic/2015-12-30_scielo.br.log.gz')
+    def test_is_valid_source_directory_false_2(self):
+        _insp = self.mocker.patch(Inspector)
+        _insp.get_collections()
+        self.mocker.result(COLLECTIONS)
+        self.mocker.replay()
+
+        insp = Inspector('/var/www/scielo.pepsic/2015-12-30_scielo.br.log.gz')
 
         self.assertFalse(insp._is_valid_source_directory())

--- a/tests/test_ratchet.py
+++ b/tests/test_ratchet.py
@@ -753,6 +753,3 @@ class RatchetBulkTests(unittest.TestCase):
         self.assertEqual(
             sorted(['%s:%s' % (k, v) for k, v in self.rb.bulk_data['S1414-431X2014000100005'].items()]), expected
         )
-
-
-

--- a/tests/test_readcube.py
+++ b/tests/test_readcube.py
@@ -121,6 +121,3 @@ class ReadCubeBulkTests(unittest.TestCase):
         am = readcube.AccessMap(sample_line)
 
         self.assertEqual(am.downloaded, '1')
-
-
-


### PR DESCRIPTION
**O que esse PR faz?**

Melhoramentos no processamento de parsing dos logs de acesso.

**Onde a revisão poderia começar?**

Verificar o arquivo accesschecker.py

**Indique o caminho do arquivo e o arquivo onde o revisor deve iniciar a leitura do código.
Como este poderia ser testado manualmente?**

path: logger/accesschecker.py

Consultar o diff do pullrequest para mais informaçao

Existem testes unitários para este desenvolvimento:

    test_parsed_access_invalid_http_status_code

**Algum cenário de contexto que queira dar?**

Ver relatório entregue à SciELO.

[Relatório Avaliaçao Ratchet.pdf](https://github.com/scieloorg/Logger/files/3525522/Relatorio.Avaliacao.Ratchet.pdf)

**Quais são tickets relevantes?**

Nao se aplica.