### PR TITLE
Adiciona suporte às novas URLs do novo site

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,6 +3,9 @@ python:
   - 2.7
 env:
   - LOGGER_SETTINGS_FILE=./config.ini
+before_install:
+    - pip install --upgrade 'setuptools<45' pip
+    - pip install -r requirements.txt
 install: 
   - python setup.py install
 script:

--- a/logger/accesschecker.py
+++ b/logger/accesschecker.py
@@ -135,7 +135,7 @@ class AccessChecker(object):
 
     def _pdf_or_html_access(self, get):
         if "GET" in get:
-            if re.search(r"[\./]pdf", get):
+            if re.search(r"[\./(format=)]pdf", get):
                 return "PDF"
 
             elif (

--- a/logger/accesschecker.py
+++ b/logger/accesschecker.py
@@ -227,14 +227,17 @@ class AccessChecker(object):
         parsed_line = self._parse_line(raw_line)
 
         if not parsed_line:
+            logger.debug('cannot parse log line "%s"', raw_line)
             return None
 
         if self.is_robot(parsed_line['%{User-Agent}i']):
+            logger.debug('cannot count log line "%s": the user-agent is blacklisted', raw_line)
             return None
 
         access_date = self._access_date(parsed_line['%t'])
 
         if not access_date:
+            logger.debug('cannot count log line "%s": missing access date', raw_line)
             return None
 
         data = {}
@@ -251,12 +254,15 @@ class AccessChecker(object):
         data['http_code'] = parsed_line['%>s']
 
         if not data['http_code'] or data['http_code'] not in ['200', '304']:
+            logger.debug('cannot count log line "%s": unsupported html status code', raw_line)
             return None
  
         if not data['access_type']:
+            logger.debug('cannot count log line "%s": missing document type', raw_line)
             return None
 
         if not data['iso_date']:
+            logger.debug('cannot count log line "%s": missing iso date', raw_line)
             return None
 
         if data['access_type'] == u'HTML':
@@ -274,13 +280,16 @@ class AccessChecker(object):
                 else:
                     # URLs do site clássico
                     if not data['query_string']:
+                        logger.debug('cannot count log line "%s": missing querystring', raw_line)
                         return None
 
                     if 'script' not in data['query_string'] or 'pid' not in data['query_string']:
+                        logger.debug('cannot count log line "%s": missing script or pid in querystring', raw_line)
                         return None
 
                     if not self._is_valid_html_request(data['query_string']['script'],
                                                        data['query_string']['pid']):
+                        logger.debug('cannot count log line "%s": request is invalid', raw_line)
                         return None
 
                     data['code'] = data['query_string']['pid']
@@ -299,6 +308,7 @@ class AccessChecker(object):
                     data['code'] = match.groupdict()['pid'] + "_pdf"
                     data['script'] = ''
                 else:
+                    logger.debug('cannot count log line "%s": request is invalid', raw_line)
                     return None
 
         return data

--- a/logger/accesschecker.py
+++ b/logger/accesschecker.py
@@ -134,11 +134,20 @@ class AccessChecker(object):
             return None
 
     def _pdf_or_html_access(self, get):
-        if "GET" in get and (".pdf" in get or "/pdf/" in get):
-            return "PDF"
+        if "GET" in get:
+            if re.search(r"[\./]pdf", get):
+                return "PDF"
 
-        if "GET" in get and ("scielo.php" in get and "script" in get and "pid" in get) or ("/article/" in get):
-            return "HTML"
+            elif (
+                    "scielo.php" in get \
+                    and "script" in get \
+                    and "pid" in get
+                ) \
+                or "format=html" in get \
+                or "/article/" in get \
+                or "/a/" in get:
+
+                return "HTML"
 
         return None
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -10,7 +10,6 @@ chardet==3.0.4
 idna==2.7
 kombu==3.0.37
 legendarium==2.0.2
--e git+https://github.com/scieloorg/logger@2.1#egg=logger
 pathtools==0.1.2
 ply==3.11
 pymongo==3.7.2

--- a/setup.py
+++ b/setup.py
@@ -18,9 +18,7 @@ install_requires = [
     'pymongo>=2.8',
     'celery>=3.1.18',
     'watchdog>=0.8.3',
-    'thriftpy>=0.3.1',
-    'xylose>=1.16.5',
-    'articlemetaapi>=1.14.19',
+    'articlemetaapi',
 ]
 
 tests_require = [

--- a/setup.py
+++ b/setup.py
@@ -48,9 +48,8 @@ setup(
     ],
     dependency_links=[],
     install_requires=install_requires,
-    setup_requires=["nose>=1.0", "coverage"],
     tests_require=tests_require,
-    test_suite="nose.collector",
+    test_suite="tests",
     entry_points="""\
     [console_scripts]
     logger_loadlogs_scielo = logger.scielo:main

--- a/tests/test_accesseschecker.py
+++ b/tests/test_accesseschecker.py
@@ -61,18 +61,25 @@ class AccessCheckerTests(unittest.TestCase):
         request = u'GET /scielo.php?pid=S0100-736X2000000300007&script=sci_arttext HTTP/1.1'
         self.assertEqual(self.ac._pdf_or_html_access(request), u'HTML')
 
-    def test_pdf_or_html_access_for_pdf_on_new_site(self):
+    def test_pdf_or_html_access_identifies_urls_of_documents_in_pdf_v1(self):
         request = u'GET https://www.scielo.br/pdf/abcd/2018.v31n3/e1382/en HTTP/1.1'
         self.assertEqual(self.ac._pdf_or_html_access(request), u'PDF')
 
         request = u'GET /pdf/abcd/2018.v31n3/e1382/en HTTP/1.1'
         self.assertEqual(self.ac._pdf_or_html_access(request), u'PDF')
 
-    def test_pdf_or_html_access_for_pdf(self):
+    def test_pdf_or_html_access_identifies_urls_of_documents_in_pdf_v2(self):
         request = u'GET http://www.scielo.br/pdf/isz/v96n2/a18v96n2.pdf HTTP/1.1'
         self.assertEqual(self.ac._pdf_or_html_access(request), u'PDF')
 
         request = u'GET /pdf/isz/v96n2/a18v96n2.pdf HTTP/1.1'
+        self.assertEqual(self.ac._pdf_or_html_access(request), u'PDF')
+
+    def test_pdf_or_html_access_identifies_urls_of_documents_in_pdf_v3(self):
+        request = u'GET http://www.scielo.br/j/abdc/a/MYJY5Rgw5gc7mBpqYzBCVJR?format=pdf HTTP/1.1'
+        self.assertEqual(self.ac._pdf_or_html_access(request), u'PDF')
+
+        request = u'GET /j/abdc/a/MYJY5Rgw5gc7mBpqYzBCVJR?format=pdf HTTP/1.1'
         self.assertEqual(self.ac._pdf_or_html_access(request), u'PDF')
 
     def test_pdf_or_html_access_for_files_on_new_site(self):

--- a/tests/test_accesseschecker.py
+++ b/tests/test_accesseschecker.py
@@ -33,14 +33,28 @@ class AccessCheckerTests(unittest.TestCase):
         agent = '"Mozilla/5.0 (Windows NT 5.1; rv:26.0) Gecko/20100101 Firefox/26.0"'
         self.assertEqual(self.ac.is_robot(agent), False)
 
-    def test_pdf_or_html_access_for_html_on_new_site(self):
+    def test_pdf_or_html_access_identifies_urls_of_documents_in_html_v1(self):
         request = u'GET http://www.scielo.br/article/abcd/2018.v31n3/e1382/pt/ HTTP/1.1'
         self.assertEqual(self.ac._pdf_or_html_access(request), u'HTML')
 
         request = u'GET /article/abcd/2018.v31n3/e1382/pt/ HTTP/1.1'
         self.assertEqual(self.ac._pdf_or_html_access(request), u'HTML')
 
-    def test_pdf_or_html_access_for_html(self):
+    def test_pdf_or_html_access_identifies_urls_of_documents_in_html_v2(self):
+        request = u'GET http://www.scielo.br/j/abdc/a/MYJY5Rgw5gc7mBpqYzBCVJR HTTP/1.1'
+        self.assertEqual(self.ac._pdf_or_html_access(request), u'HTML')
+
+        request = u'GET /j/abdc/a/MYJY5Rgw5gc7mBpqYzBCVJR HTTP/1.1'
+        self.assertEqual(self.ac._pdf_or_html_access(request), u'HTML')
+
+    def test_pdf_or_html_access_identifies_urls_of_documents_in_html_v3(self):
+        request = u'GET http://www.scielo.br/j/abdc/a/MYJY5Rgw5gc7mBpqYzBCVJR?format=html HTTP/1.1'
+        self.assertEqual(self.ac._pdf_or_html_access(request), u'HTML')
+
+        request = u'GET /j/abdc/a/MYJY5Rgw5gc7mBpqYzBCVJR?format=html HTTP/1.1'
+        self.assertEqual(self.ac._pdf_or_html_access(request), u'HTML')
+
+    def test_pdf_or_html_access_identifies_urls_of_documents_in_html_v4(self):
         request = u'GET http://www.scielo.br/scielo.php?pid=S0100-736X2000000300007&script=sci_arttext HTTP/1.1'
         self.assertEqual(self.ac._pdf_or_html_access(request), u'HTML')
 

--- a/tests/test_accesseschecker.py
+++ b/tests/test_accesseschecker.py
@@ -240,7 +240,7 @@ class OPACURLParsingTests(unittest.TestCase):
             acronym_to_issn_dict=lambda col: {u'zool': u'1984-4670', u'bjmbr': u'1414-431X'},
         )
 
-    def test_document_url(self):
+    def test_document_url_v1(self):
         """URL de artigo em HTML no padrão do novo site. Este padrão já foi
         suplantado, mas podem haver instâncias que o utilizam. 
         """
@@ -249,6 +249,52 @@ class OPACURLParsingTests(unittest.TestCase):
         expected = {
                         'ip': '187.19.211.179',
                         'code': '/article/bjmbr/2018.v51n11/e7704/',
+                        'access_type': 'HTML',
+                        'iso_date': '2013-05-30',
+                        'iso_datetime': '2013-05-30T00:01:01',
+                        'year': '2013',
+                        'query_string': None,
+                        'day': '30',
+                        'http_code': '200',
+                        'original_agent': 'Mozilla/5.0 (compatible; MSIE 10.0; Windows NT 6.1; Trident/6.0)',
+                        'original_date': '[30/May/2013:00:01:01 -0300]',
+                        'script': '',
+                        'month': '05'
+                    }
+
+        self.assertEqual(self.ac.parsed_access(line), expected)
+
+    def test_document_url_v2(self):
+        """URL de artigo em HTML no padrão do novo site.
+        """
+        line = '187.19.211.179 - - [30/May/2013:00:01:01 -0300] "GET  https://www.scielo.br/j/bjmbr/a/F5Zr9TrzfmMgz9kvGZL3rZB HTTP/1.1" 200 25084 "-" "Mozilla/5.0 (compatible; MSIE 10.0; Windows NT 6.1; Trident/6.0)"'
+
+        expected = {
+                        'ip': '187.19.211.179',
+                        'code': 'F5Zr9TrzfmMgz9kvGZL3rZB',
+                        'access_type': 'HTML',
+                        'iso_date': '2013-05-30',
+                        'iso_datetime': '2013-05-30T00:01:01',
+                        'year': '2013',
+                        'query_string': None,
+                        'day': '30',
+                        'http_code': '200',
+                        'original_agent': 'Mozilla/5.0 (compatible; MSIE 10.0; Windows NT 6.1; Trident/6.0)',
+                        'original_date': '[30/May/2013:00:01:01 -0300]',
+                        'script': '',
+                        'month': '05'
+                    }
+
+        self.assertEqual(self.ac.parsed_access(line), expected)
+
+    def test_document_url_v3(self):
+        """URL de artigo em HTML no padrão do novo site.
+        """
+        line = '187.19.211.179 - - [30/May/2013:00:01:01 -0300] "GET  https://www.scielo.br/j/bjmbr/a/F5Zr9TrzfmMgz9kvGZL3rZB?format=html HTTP/1.1" 200 25084 "-" "Mozilla/5.0 (compatible; MSIE 10.0; Windows NT 6.1; Trident/6.0)"'
+
+        expected = {
+                        'ip': '187.19.211.179',
+                        'code': 'F5Zr9TrzfmMgz9kvGZL3rZB',
                         'access_type': 'HTML',
                         'iso_date': '2013-05-30',
                         'iso_datetime': '2013-05-30T00:01:01',
@@ -287,7 +333,7 @@ class OPACURLParsingTests(unittest.TestCase):
                     }
         self.assertEqual(self.ac.parsed_access(line), expected)
 
-    def test_pdf_url(self):
+    def test_pdf_url_v1(self):
         """URL de artigo em PDF no padrão do novo site. Este padrão já foi
         suplantado, mas podem haver instâncias que o utilizam. 
         """
@@ -311,7 +357,30 @@ class OPACURLParsingTests(unittest.TestCase):
                     }
         self.assertEqual(self.ac.parsed_access(line), expected)
 
-    def test_pdf_relative_url(self):
+    def test_pdf_url_v2(self):
+        """URL de artigo em HTML no padrão do novo site.
+        """
+        line = '187.19.211.179 - - [30/May/2013:00:01:01 -0300] "GET  https://www.scielo.br/j/bjmbr/a/F5Zr9TrzfmMgz9kvGZL3rZB?format=pdf HTTP/1.1" 200 25084 "-" "Mozilla/5.0 (compatible; MSIE 10.0; Windows NT 6.1; Trident/6.0)"'
+
+        expected = {
+                        'ip': '187.19.211.179',
+                        'code': 'F5Zr9TrzfmMgz9kvGZL3rZB_pdf',
+                        'access_type': 'PDF',
+                        'iso_date': '2013-05-30',
+                        'iso_datetime': '2013-05-30T00:01:01',
+                        'year': '2013',
+                        'query_string': None,
+                        'day': '30',
+                        'http_code': '200',
+                        'original_agent': 'Mozilla/5.0 (compatible; MSIE 10.0; Windows NT 6.1; Trident/6.0)',
+                        'original_date': '[30/May/2013:00:01:01 -0300]',
+                        'script': '',
+                        'month': '05'
+                    }
+
+        self.assertEqual(self.ac.parsed_access(line), expected)
+
+    def test_pdf_relative_url_v1(self):
         """URL de artigo em PDF no padrão do novo site. Trata-se da mesma URL
         do caso `test_pdf_url` mas com a URL relativa e não absoluta.
         """

--- a/tests/test_accesseschecker.py
+++ b/tests/test_accesseschecker.py
@@ -500,6 +500,14 @@ class ClassicSiteURLParsingTests(unittest.TestCase):
                     }
         self.assertEqual(self.ac.parsed_access(line), expected)
 
+    def test_document_pdf_url_v2(self):
+        line = '201.14.120.2 - - [30/May/2013:00:01:01 -0300] "GET http://www.scielo.br/scielo.php?pid=S0044-59672020000100012&script=sci_pdf&tlng=en HTTP/1.1" 200 4608 "-" "Mozilla/5.0 (compatible; MSIE 10.0; Windows NT 6.1; Trident/6.0)"'
+        self.assertEqual(self.ac.parsed_access(line), None)
+
+    def test_journal_homepage(self):
+        line = '201.14.120.2 - - [30/May/2013:00:01:01 -0300] "GET http://www.scielo.br/scielo.php?script=sci_serial&pid=0100-879X&lng=en&nrm=iso HTTP/1.1" 200 4608 "-" "Mozilla/5.0 (compatible; MSIE 10.0; Windows NT 6.1; Trident/6.0)"'
+        self.assertEqual(self.ac.parsed_access(line), None)
+
     def test_document_pdf_with_unknown_journal_acronym(self):
         line = '201.14.120.2 - - [30/May/2013:00:01:01 -0300] "GET http://www.scielo.br/pdf/not_allowed_acronym/v14n4/03.pdf HTTP/1.1" 200 4608 "-" "Mozilla/5.0 (compatible; MSIE 10.0; Windows NT 6.1; Trident/6.0)"'
         self.assertEqual(self.ac.parsed_access(line), None)

--- a/tests/test_accesseschecker.py
+++ b/tests/test_accesseschecker.py
@@ -1,214 +1,81 @@
 # coding: utf-8
 import unittest
-import urllib2
-import datetime
-
-from mocker import ANY, MockerTestCase
 
 from logger.accesschecker import AccessChecker
-from . import fixtures
 
 
-class AccessCheckerTests(MockerTestCase):
+class AccessCheckerTests(unittest.TestCase):
+    def setUp(self):
+        self.ac = AccessChecker(
+            collection="scl", 
+            allowed_collections=lambda: [u"scl", u"arg"],
+            acronym_to_issn_dict=lambda col: {u'zool': u'1984-4670', u'bjmbr': u'1414-431X'},
+        )
+
 
     def test_is_bot_GoogleBot_sample(self):
-        accesschecker = self.mocker.patch(AccessChecker)
-        accesschecker._allowed_collections()
-        self.mocker.result([u'scl', u'arg'])
-        accesschecker._acronym_to_issn_dict()
-        self.mocker.result({u'zool': u'1984-4670', u'bjmbr': u'1414-431X'})
-
-        self.mocker.replay()
-
-        ac = AccessChecker(collection='scl')
-
         line = '66.249.75.131 - - [24/Dec/2013:04:49:09 -0200] "GET http://www.scielo.br/scielo.php?script=sci_arttext&pid=S0102-79722002000200013 HTTP/1.1" 200 102967 "-" "Mozilla/5.0 (compatible; Googlebot/2.1; +http://www.google.com/bot.html)"'
-        
-        self.assertEqual(ac.parsed_access(line), None)
+        self.assertEqual(self.ac.parsed_access(line), None)
 
     def test_is_bot_Bing_sample(self):
-        accesschecker = self.mocker.patch(AccessChecker)
-        accesschecker._allowed_collections()
-        self.mocker.result([u'scl', u'arg'])
-        accesschecker._acronym_to_issn_dict()
-        self.mocker.result({u'zool': u'1984-4670', u'bjmbr': u'1414-431X'})
-
-        self.mocker.replay()
-
-        ac = AccessChecker(collection='scl')
-
         line = '13245  157.56.92.164 - - [30/Nov/2013:03:53:26 -0200] "GET http://www.scielo.br/scielo.php?script=sci_arttext&pid=S0104-87752010000200013 HTTP/1.1" 200 108777 "-" "Mozilla/5.0 (compatible; bingbot/2.0; +http://www.bing.com/bingbot.htm)"'
-        
-        self.assertEqual(ac.parsed_access(line), None)
+        self.assertEqual(self.ac.parsed_access(line), None)
 
     def test_is_bot_Spider_sample(self):
-        accesschecker = self.mocker.patch(AccessChecker)
-        accesschecker._allowed_collections()
-        self.mocker.result([u'scl', u'arg'])
-        accesschecker._acronym_to_issn_dict()
-        self.mocker.result({u'zool': u'1984-4670', u'bjmbr': u'1414-431X'})
-
-        self.mocker.replay()
-
-        ac = AccessChecker(collection='scl')
-
         line = '180.76.5.118 - - [24/Dec/2013:04:49:09 -0200] "GET http://www.scielo.br/pdf/csc/v11n2/30434.pdf HTTP/1.1" 200 79618 "-" "Mozilla/5.0 (compatible; Baiduspider/2.0; +http://www.baidu.com/search/spider.html)"'
-        
-        self.assertEqual(ac.parsed_access(line), None)
+        self.assertEqual(self.ac.parsed_access(line), None)
 
     def test_is_bot_method_with_bot_agent(self):
-        accesschecker = self.mocker.patch(AccessChecker)
-        accesschecker._allowed_collections()
-        self.mocker.result([u'scl', u'arg'])
-        accesschecker._acronym_to_issn_dict()
-        self.mocker.result({u'zool': u'1984-4670', u'bjmbr': u'1414-431X'})
-
-        self.mocker.replay()
-
-        ac = AccessChecker(collection='scl')
-
         agent = '"Mozilla/5.0 (compatible; Baiduspider/2.0; +http://www.baidu.com/search/spider.html)"'
-
-        self.assertEqual(ac.is_robot(agent), True)
+        self.assertEqual(self.ac.is_robot(agent), True)
 
     def test_is_bot_method_with_common_user_agent(self):
-        accesschecker = self.mocker.patch(AccessChecker)
-        accesschecker._allowed_collections()
-        self.mocker.result([u'scl', u'arg'])
-        accesschecker._acronym_to_issn_dict()
-        self.mocker.result({u'zool': u'1984-4670', u'bjmbr': u'1414-431X'})
-
-        self.mocker.replay()
-
-        ac = AccessChecker(collection='scl')
-
         agent = '"Mozilla/5.0 (Windows NT 5.1; rv:26.0) Gecko/20100101 Firefox/26.0"'
-
-        self.assertEqual(ac.is_robot(agent), False)
+        self.assertEqual(self.ac.is_robot(agent), False)
 
     def test_pdf_or_html_access_for_html_on_new_site(self):
-        accesschecker = self.mocker.patch(AccessChecker)
-        accesschecker._allowed_collections()
-        self.mocker.result(['scl', 'arg'])
-        accesschecker._acronym_to_issn_dict()
-        self.mocker.result({u'zool': u'1984-4670', u'bjmbr': u'1414-431X'})
-        self.mocker.replay()
-
-        ac = AccessChecker(collection='scl')
-
         request = u'GET http://www.scielo.br/article/abcd/2018.v31n3/e1382/pt/ HTTP/1.1'
-
-        self.assertEqual(ac._pdf_or_html_access(request), u'HTML')
+        self.assertEqual(self.ac._pdf_or_html_access(request), u'HTML')
 
         request = u'GET /article/abcd/2018.v31n3/e1382/pt/ HTTP/1.1'
-
-        self.assertEqual(ac._pdf_or_html_access(request), u'HTML')
+        self.assertEqual(self.ac._pdf_or_html_access(request), u'HTML')
 
     def test_pdf_or_html_access_for_html(self):
-        accesschecker = self.mocker.patch(AccessChecker)
-        accesschecker._allowed_collections()
-        self.mocker.result(['scl', 'arg'])
-        accesschecker._acronym_to_issn_dict()
-        self.mocker.result({u'zool': u'1984-4670', u'bjmbr': u'1414-431X'})
-        self.mocker.replay()
-
-        ac = AccessChecker(collection='scl')
-
         request = u'GET http://www.scielo.br/scielo.php?pid=S0100-736X2000000300007&script=sci_arttext HTTP/1.1'
-
-        self.assertEqual(ac._pdf_or_html_access(request), u'HTML')
+        self.assertEqual(self.ac._pdf_or_html_access(request), u'HTML')
 
         request = u'GET /scielo.php?pid=S0100-736X2000000300007&script=sci_arttext HTTP/1.1'
-
-        self.assertEqual(ac._pdf_or_html_access(request), u'HTML')
+        self.assertEqual(self.ac._pdf_or_html_access(request), u'HTML')
 
     def test_pdf_or_html_access_for_pdf_on_new_site(self):
-        accesschecker = self.mocker.patch(AccessChecker)
-        accesschecker._allowed_collections()
-        self.mocker.result(['scl', 'arg'])
-        accesschecker._acronym_to_issn_dict()
-        self.mocker.result({u'zool': u'1984-4670', u'bjmbr': u'1414-431X'})
-
-        self.mocker.replay()
-
-        ac = AccessChecker(collection='scl')
-
         request = u'GET https://www.scielo.br/pdf/abcd/2018.v31n3/e1382/en HTTP/1.1'
-
-        self.assertEqual(ac._pdf_or_html_access(request), u'PDF')
+        self.assertEqual(self.ac._pdf_or_html_access(request), u'PDF')
 
         request = u'GET /pdf/abcd/2018.v31n3/e1382/en HTTP/1.1'
-
-        self.assertEqual(ac._pdf_or_html_access(request), u'PDF')
+        self.assertEqual(self.ac._pdf_or_html_access(request), u'PDF')
 
     def test_pdf_or_html_access_for_pdf(self):
-        accesschecker = self.mocker.patch(AccessChecker)
-        accesschecker._allowed_collections()
-        self.mocker.result(['scl', 'arg'])
-        accesschecker._acronym_to_issn_dict()
-        self.mocker.result({u'zool': u'1984-4670', u'bjmbr': u'1414-431X'})
-
-        self.mocker.replay()
-
-        ac = AccessChecker(collection='scl')
-
         request = u'GET http://www.scielo.br/pdf/isz/v96n2/a18v96n2.pdf HTTP/1.1'
-
-        self.assertEqual(ac._pdf_or_html_access(request), u'PDF')
+        self.assertEqual(self.ac._pdf_or_html_access(request), u'PDF')
 
         request = u'GET /pdf/isz/v96n2/a18v96n2.pdf HTTP/1.1'
-
-        self.assertEqual(ac._pdf_or_html_access(request), u'PDF')
+        self.assertEqual(self.ac._pdf_or_html_access(request), u'PDF')
 
     def test_pdf_or_html_access_for_files_on_new_site(self):
-        accesschecker = self.mocker.patch(AccessChecker)
-        accesschecker._allowed_collections()
-        self.mocker.result([u'scl', u'arg'])
-        accesschecker._acronym_to_issn_dict()
-        self.mocker.result({u'zool': u'1984-4670', u'bjmbr': u'1414-431X'})
-
-        self.mocker.replay()
-
-        ac = AccessChecker(collection='scl')
-
         request = u'GET http://www.scielo.br/static/img/favicon.ico HTTP/1.1'
-
-        self.assertEqual(ac._pdf_or_html_access(request), None)
+        self.assertEqual(self.ac._pdf_or_html_access(request), None)
 
         request = u'GET /static/img/favicon.ico HTTP/1.1'
-
-        self.assertEqual(ac._pdf_or_html_access(request), None)
+        self.assertEqual(self.ac._pdf_or_html_access(request), None)
 
     def test_pdf_or_html_access_for_files(self):
-        accesschecker = self.mocker.patch(AccessChecker)
-        accesschecker._allowed_collections()
-        self.mocker.result([u'scl', u'arg'])
-        accesschecker._acronym_to_issn_dict()
-        self.mocker.result({u'zool': u'1984-4670', u'bjmbr': u'1414-431X'})
-
-        self.mocker.replay()
-
-        ac = AccessChecker(collection='scl')
-
         request = u'GET http://www.scielo.br/css/screen/styles.css HTTP/1.1'
-
-        self.assertEqual(ac._pdf_or_html_access(request), None)
+        self.assertEqual(self.ac._pdf_or_html_access(request), None)
 
         request = u'GET /css/screen/styles.css HTTP/1.1'
-
-        self.assertEqual(ac._pdf_or_html_access(request), None)
+        self.assertEqual(self.ac._pdf_or_html_access(request), None)
 
     def test_parse_line_with_apache_line(self):
-        accesschecker = self.mocker.patch(AccessChecker)
-        accesschecker._allowed_collections()
-        self.mocker.result([u'scl', u'arg'])
-        accesschecker._acronym_to_issn_dict()
-        self.mocker.result({u'zool': u'1984-4670', u'bjmbr': u'1414-431X'})
-
-        self.mocker.replay()
-
-        ac = AccessChecker(collection='scl')
-
         line = '187.19.211.179 - - [30/May/2013:00:01:01 -0300] "GET http://www.scielo.br/scielo.php?pid=S0100-736X2000000300007&script=sci_arttext HTTP/1.1" 200 25084 "-" "Mozilla/5.0 (compatible; MSIE 10.0; Windows NT 6.1; Trident/6.0)"'
 
         expected = {
@@ -223,7 +90,7 @@ class AccessCheckerTests(MockerTestCase):
                     '%r': 'GET http://www.scielo.br/scielo.php?pid=S0100-736X2000000300007&script=sci_arttext HTTP/1.1'
                     }
 
-        self.assertEqual(ac._parse_line(line), expected)
+        self.assertEqual(self.ac._parse_line(line), expected)
 
         line = '123.125.71.39 - - [30/Dec/2012:23:59:57 -0200] "GET /scielo.php?script=sci_nlinks&ref=000144&pid=S0103-4014200000020001300010&lng=pt HTTP/1.1" 200 1878 "-" "Mozilla/5.0 (compatible; Baiduspider/2.0; +http://www.baidu.com/search/spider.html)"'
 
@@ -239,429 +106,111 @@ class AccessCheckerTests(MockerTestCase):
                     '%r': 'GET /scielo.php?script=sci_nlinks&ref=000144&pid=S0103-4014200000020001300010&lng=pt HTTP/1.1'
                     }
 
-        self.assertEqual(ac._parse_line(line), expected)
+        self.assertEqual(self.ac._parse_line(line), expected)
 
     def test_parse_line_invalid_line(self):
-        accesschecker = self.mocker.patch(AccessChecker)
-        accesschecker._allowed_collections()
-        self.mocker.result([u'scl', u'arg'])
-        accesschecker._acronym_to_issn_dict()
-        self.mocker.result({u'zool': u'1984-4670', u'bjmbr': u'1414-431X'})
-
-        self.mocker.replay()
-
-        ac = AccessChecker(collection='scl')
-
-        line = ''
-
-        self.assertEqual(ac._parse_line(line), None)
+        self.assertEqual(self.ac._parse_line(''), None)
 
     def test_access_date(self):
-        accesschecker = self.mocker.patch(AccessChecker)
-        accesschecker._allowed_collections()
-        self.mocker.result([u'scl', u'arg'])
-        accesschecker._acronym_to_issn_dict()
-        self.mocker.result({u'zool': u'1984-4670', u'bjmbr': u'1414-431X'})
-
-        self.mocker.replay()
-
-        ac = AccessChecker(collection='scl')
-
         access_date = u'[30/Dec/2012:23:59:57 -0200]'
-
-        self.assertEqual(ac._access_date(access_date).date().isoformat(), u'2012-12-30')
+        self.assertEqual(self.ac._access_date(access_date).date().isoformat(), u'2012-12-30')
 
     def test_access_datetime(self):
-        accesschecker = self.mocker.patch(AccessChecker)
-        accesschecker._allowed_collections()
-        self.mocker.result([u'scl', u'arg'])
-        accesschecker._acronym_to_issn_dict()
-        self.mocker.result({u'zool': u'1984-4670', u'bjmbr': u'1414-431X'})
-
-        self.mocker.replay()
-
-        ac = AccessChecker(collection='scl')
-
         access_date = u'[30/Dec/2012:23:59:57 -0200]'
-
-        self.assertEqual(ac._access_date(access_date).isoformat(), u'2012-12-30T23:59:57')
+        self.assertEqual(self.ac._access_date(access_date).isoformat(), u'2012-12-30T23:59:57')
 
     def test_access_date_with_invalid_month(self):
-        accesschecker = self.mocker.patch(AccessChecker)
-        accesschecker._allowed_collections()
-        self.mocker.result([u'scl', u'arg'])
-        accesschecker._acronym_to_issn_dict()
-        self.mocker.result({u'zool': u'1984-4670', u'bjmbr': u'1414-431X'})
-
-        self.mocker.replay()
-
-        ac = AccessChecker(collection='scl')
-
         access_date = u'[30/xxx/2012:23:59:57 -0200]'
-
-        self.assertEqual(ac._access_date(access_date), None)
+        self.assertEqual(self.ac._access_date(access_date), None)
 
     def test_access_date_with_invalid_day(self):
-        accesschecker = self.mocker.patch(AccessChecker)
-        accesschecker._allowed_collections()
-        self.mocker.result([u'scl', u'arg'])
-        accesschecker._acronym_to_issn_dict()
-        self.mocker.result({u'zool': u'1984-4670', u'bjmbr': u'1414-431X'})
-
-        self.mocker.replay()
-
-        ac = AccessChecker(collection='scl')
-
         access_date = u'[xx/Dec/2012:23:59:57 -0200]'
-
-        self.assertEqual(ac._access_date(access_date), None)
+        self.assertEqual(self.ac._access_date(access_date), None)
 
     def test_access_date_with_invalid_year(self):
-        accesschecker = self.mocker.patch(AccessChecker)
-        accesschecker._allowed_collections()
-        self.mocker.result([u'scl', u'arg'])
-        accesschecker._acronym_to_issn_dict()
-        self.mocker.result({u'zool': u'1984-4670', u'bjmbr': u'1414-431X'})
-
-        self.mocker.replay()
-
-        ac = AccessChecker(collection='scl')
-
         access_date = u'[12/Dec/x012:23:59:57 -0200]'
-
-        self.assertEqual(ac._access_date(access_date), None)
+        self.assertEqual(self.ac._access_date(access_date), None)
 
     def test_access_date_with_invalid_date(self):
-        accesschecker = self.mocker.patch(AccessChecker)
-        accesschecker._allowed_collections()
-        self.mocker.result([u'scl', u'arg'])
-        accesschecker._acronym_to_issn_dict()
-        self.mocker.result({u'zool': u'1984-4670', u'bjmbr': u'1414-431X'})
-
-        self.mocker.replay()
-
-        ac = AccessChecker(collection='scl')
-
-        access_date = u''
-
-        self.assertEqual(ac._access_date(access_date), None)
+        self.assertEqual(self.ac._access_date(u''), None)
 
     def test_query_string_with_parameters(self):
-        accesschecker = self.mocker.patch(AccessChecker)
-        accesschecker._allowed_collections()
-        self.mocker.result([u'scl', u'arg'])
-        accesschecker._acronym_to_issn_dict()
-        self.mocker.result({u'zool': u'1984-4670', u'bjmbr': u'1414-431X'})
-
-        self.mocker.replay()
-
-        ac = AccessChecker(collection='scl')
-
         url = u'GET http://www.scielo.br/scielo.php?pid=S0100-736X2000000300007&script=sci_arttext HTTP/1.1'
-
-        self.assertEqual(ac._query_string(url), {u'pid': u'S0100-736X2000000300007', u'script': u'sci_arttext'})
+        self.assertEqual(self.ac._query_string(url), {u'pid': u'S0100-736X2000000300007', u'script': u'sci_arttext'})
 
         url = u'GET /scielo.php?pid=S0100-736X2000000300007&script=sci_arttext HTTP/1.1'
-
-        self.assertEqual(ac._query_string(url), {u'pid': u'S0100-736X2000000300007', u'script': u'sci_arttext'})
+        self.assertEqual(self.ac._query_string(url), {u'pid': u'S0100-736X2000000300007', u'script': u'sci_arttext'})
 
     def test_query_string_without_parameters(self):
-        accesschecker = self.mocker.patch(AccessChecker)
-        accesschecker._allowed_collections()
-        self.mocker.result([u'scl', u'arg'])
-        accesschecker._acronym_to_issn_dict()
-        self.mocker.result({u'zool': u'1984-4670', u'bjmbr': u'1414-431X'})
-
-        self.mocker.replay()
-
-        ac = AccessChecker(collection='scl')
-
         url = u'GET http://www.scielo.br/scielo.php HTTP/1.1'
-
-        self.assertEqual(ac._query_string(url), None)
+        self.assertEqual(self.ac._query_string(url), None)
 
     def test_pid_is_valid_not_allowed_issn(self):
-        accesschecker = self.mocker.patch(AccessChecker)
-        accesschecker._allowed_collections()
-        self.mocker.result([u'scl', u'arg'])
-        accesschecker._acronym_to_issn_dict()
-        self.mocker.result({u'zool': u'1984-4670', u'bjmbr': u'1414-431X'})
-
-        self.mocker.replay()
-
-        ac = AccessChecker(collection='scl')
-
-        self.assertEqual(ac._is_valid_html_request('sci_arttext', 'XXXX-XXXX2012000100001'), False)
+        self.assertEqual(self.ac._is_valid_html_request('sci_arttext', 'XXXX-XXXX2012000100001'), False)
 
     def test_pid_is_valid_script_sci_arttext_invalid_pid(self):
-        accesschecker = self.mocker.patch(AccessChecker)
-        accesschecker._allowed_collections()
-        self.mocker.result([u'scl', u'arg'])
-        accesschecker._acronym_to_issn_dict()
-        self.mocker.result({u'zool': u'1984-4670', u'bjmbr': u'1414-431X'})
-
-        self.mocker.replay()
-
-        ac = AccessChecker(collection='scl')
-
-        self.assertEqual(ac._is_valid_html_request('sci_arttext', '123443212012000100001'), False)
+        self.assertEqual(self.ac._is_valid_html_request('sci_arttext', '123443212012000100001'), False)
 
     def test_pid_is_valid_script_sci_arttext_valid_pid(self):
-        accesschecker = self.mocker.patch(AccessChecker)
-        accesschecker._allowed_collections()
-        self.mocker.result([u'scl', u'arg'])
-        accesschecker._acronym_to_issn_dict()
-        self.mocker.result({u'zool': u'1984-4670', u'bjmbr': u'1414-431X'})
-
-        self.mocker.replay()
-
-        ac = AccessChecker(collection='scl')
-
-        self.assertEqual(ac._is_valid_html_request('sci_arttext', '1414-431X2012000100001'), True)
+        self.assertEqual(self.ac._is_valid_html_request('sci_arttext', '1414-431X2012000100001'), True)
 
     def test_pid_is_valid_script_sci_arttext_valid_pid_fbpe(self):
-        accesschecker = self.mocker.patch(AccessChecker)
-        accesschecker._allowed_collections()
-        self.mocker.result([u'scl', u'arg'])
-        accesschecker._acronym_to_issn_dict()
-        self.mocker.result({u'zool': u'1984-4670', u'bjmbr': u'1414-431X'})
-
-        self.mocker.replay()
-
-        ac = AccessChecker(collection='scl')
-
-        self.assertEqual(ac._is_valid_html_request('sci_arttext', '1414-431X(12)00100001'), True)
+        self.assertEqual(self.ac._is_valid_html_request('sci_arttext', '1414-431X(12)00100001'), True)
 
     def test_pid_is_valid_script_sci_abstract_invalid_pid(self):
-        accesschecker = self.mocker.patch(AccessChecker)
-        accesschecker._allowed_collections()
-        self.mocker.result([u'scl', u'arg'])
-        accesschecker._acronym_to_issn_dict()
-        self.mocker.result({u'zool': u'1984-4670', u'bjmbr': u'1414-431X'})
-
-        self.mocker.replay()
-
-        ac = AccessChecker(collection='scl')
-
-        self.assertEqual(ac._is_valid_html_request('sci_abstract', '1414-431X201200100001'), False)
+        self.assertEqual(self.ac._is_valid_html_request('sci_abstract', '1414-431X201200100001'), False)
 
     def test_pid_is_valid_script_sci_abstract_valid_pid(self):
-        accesschecker = self.mocker.patch(AccessChecker)
-        accesschecker._allowed_collections()
-        self.mocker.result([u'scl', u'arg'])
-        accesschecker._acronym_to_issn_dict()
-        self.mocker.result({u'zool': u'1984-4670', u'bjmbr': u'1414-431X'})
-
-        self.mocker.replay()
-
-        ac = AccessChecker(collection='scl')
-
-        self.assertEqual(ac._is_valid_html_request('sci_abstract', '1414-431X2012000100001'), True)
+        self.assertEqual(self.ac._is_valid_html_request('sci_abstract', '1414-431X2012000100001'), True)
 
     def test_pid_is_valid_script_sci_abstract_valid_pid_fbpe(self):
-        accesschecker = self.mocker.patch(AccessChecker)
-        accesschecker._allowed_collections()
-        self.mocker.result([u'scl', u'arg'])
-        accesschecker._acronym_to_issn_dict()
-        self.mocker.result({u'zool': u'1984-4670', u'bjmbr': u'1414-431X'})
-
-        self.mocker.replay()
-
-        ac = AccessChecker(collection='scl')
-
-        self.assertEqual(ac._is_valid_html_request('sci_abstract', '1414-431X(12)00100001'), True)
+        self.assertEqual(self.ac._is_valid_html_request('sci_abstract', '1414-431X(12)00100001'), True)
 
     def test_pid_is_valid_script_sci_pdf_invalid_pid(self):
-        accesschecker = self.mocker.patch(AccessChecker)
-        accesschecker._allowed_collections()
-        self.mocker.result([u'scl', u'arg'])
-        accesschecker._acronym_to_issn_dict()
-        self.mocker.result({u'zool': u'1984-4670', u'bjmbr': u'1414-431X'})
-
-        self.mocker.replay()
-
-        ac = AccessChecker(collection='scl')
-
-        self.assertEqual(ac._is_valid_html_request('sci_pdf', '1414-431X9012000100001'), False)
+        self.assertEqual(self.ac._is_valid_html_request('sci_pdf', '1414-431X9012000100001'), False)
 
     def test_pid_is_valid_script_sci_pdf_valid_pid(self):
-        accesschecker = self.mocker.patch(AccessChecker)
-        accesschecker._allowed_collections()
-        self.mocker.result([u'scl', u'arg'])
-        accesschecker._acronym_to_issn_dict()
-        self.mocker.result({u'zool': u'1984-4670', u'bjmbr': u'1414-431X'})
-
-        self.mocker.replay()
-
-        ac = AccessChecker(collection='scl')
-
-        self.assertEqual(ac._is_valid_html_request('sci_pdf', '1414-431X2012000100001'), True)
+        self.assertEqual(self.ac._is_valid_html_request('sci_pdf', '1414-431X2012000100001'), True)
 
     def test_pid_is_valid_script_sci_pdf_valid_pid_fbpe(self):
-        accesschecker = self.mocker.patch(AccessChecker)
-        accesschecker._allowed_collections()
-        self.mocker.result([u'scl', u'arg'])
-        accesschecker._acronym_to_issn_dict()
-        self.mocker.result({u'zool': u'1984-4670', u'bjmbr': u'1414-431X'})
-
-        self.mocker.replay()
-
-        ac = AccessChecker(collection='scl')
-
-        self.assertEqual(ac._is_valid_html_request('sci_pdf', '1414-431X(12)00100001'), True)
+        self.assertEqual(self.ac._is_valid_html_request('sci_pdf', '1414-431X(12)00100001'), True)
 
     def test_pid_is_valid_script_sci_serial_valid_pid(self):
-        accesschecker = self.mocker.patch(AccessChecker)
-        accesschecker._allowed_collections()
-        self.mocker.result([u'scl', u'arg'])
-        accesschecker._acronym_to_issn_dict()
-        self.mocker.result({u'zool': u'1984-4670', u'bjmbr': u'1414-431X'})
-
-        self.mocker.replay()
-
-        ac = AccessChecker(collection='scl')
-
-        self.assertEqual(ac._is_valid_html_request('sci_serial', '1414-431X'), True)
+        self.assertEqual(self.ac._is_valid_html_request('sci_serial', '1414-431X'), True)
 
     def test_pid_is_valid_script_sci_issuetoc_valid_pid(self):
-        accesschecker = self.mocker.patch(AccessChecker)
-        accesschecker._allowed_collections()
-        self.mocker.result([u'scl', u'arg'])
-        accesschecker._acronym_to_issn_dict()
-        self.mocker.result({u'zool': u'1984-4670', u'bjmbr': u'1414-431X'})
-
-        self.mocker.replay()
-
-        ac = AccessChecker(collection='scl')
-
-        self.assertEqual(ac._is_valid_html_request('sci_issuetoc', '1414-431X20120001'), True)
+        self.assertEqual(self.ac._is_valid_html_request('sci_issuetoc', '1414-431X20120001'), True)
 
     def test_pid_is_valid_script_sci_issuetoc_invalid_pid(self):
-        accesschecker = self.mocker.patch(AccessChecker)
-        accesschecker._allowed_collections()
-        self.mocker.result([u'scl', u'arg'])
-        accesschecker._acronym_to_issn_dict()
-        self.mocker.result({u'zool': u'1984-4670', u'bjmbr': u'1414-431X'})
-
-        self.mocker.replay()
-
-        ac = AccessChecker(collection='scl')
-
-        self.assertEqual(ac._is_valid_html_request('sci_issuetoc', '1234432120120001'), False)
+        self.assertEqual(self.ac._is_valid_html_request('sci_issuetoc', '1234432120120001'), False)
 
     def test_pid_is_valid_script_sci_issues_valid_pid(self):
-        accesschecker = self.mocker.patch(AccessChecker)
-        accesschecker._allowed_collections()
-        self.mocker.result([u'scl', u'arg'])
-        accesschecker._acronym_to_issn_dict()
-        self.mocker.result({u'zool': u'1984-4670', u'bjmbr': u'1414-431X'})
-
-        self.mocker.replay()
-
-        ac = AccessChecker(collection='scl')
-        self.assertEqual(ac._is_valid_html_request('sci_issues', '1414-431X'), True)
+        self.assertEqual(self.ac._is_valid_html_request('sci_issues', '1414-431X'), True)
 
     def test_pid_is_valid_pdf_request(self):
-        accesschecker = self.mocker.patch(AccessChecker)
-        accesschecker._allowed_collections()
-        self.mocker.result([u'scl', u'arg'])
-        accesschecker._acronym_to_issn_dict()
-        self.mocker.result({u'zool': u'1984-4670', u'bjmbr': u'1414-431X'})
-
-        self.mocker.replay()
-
-        ac = AccessChecker(collection='scl')
-
         request = u'GET http://www.scielo.br/pdf/zool/v96n2/a18v96n2.pdf HTTP/1.1'
-
-        self.assertEqual(ac._is_valid_pdf_request(request), {'pdf_issn': u'1984-4670', 'pdf_path': u'/pdf/zool/v96n2/a18v96n2.pdf'})
+        self.assertEqual(self.ac._is_valid_pdf_request(request), {'pdf_issn': u'1984-4670', 'pdf_path': u'/pdf/zool/v96n2/a18v96n2.pdf'})
 
     def test_pid_is_valid_pdf_request_GET_without_domain(self):
-        accesschecker = self.mocker.patch(AccessChecker)
-        accesschecker._allowed_collections()
-        self.mocker.result([u'scl', u'arg'])
-        accesschecker._acronym_to_issn_dict()
-        self.mocker.result({u'zool': u'1984-4670', u'bjmbr': u'1414-431X'})
-
-        self.mocker.replay()
-
-        ac = AccessChecker(collection='scl')
-
         request = u'GET /pdf/zool/v29n4/18781.pdf HTTP/1.1'
-
-        self.assertEqual(ac._is_valid_pdf_request(request), {'pdf_issn': u'1984-4670', 'pdf_path': u'/pdf/zool/v29n4/18781.pdf'})
+        self.assertEqual(self.ac._is_valid_pdf_request(request), {'pdf_issn': u'1984-4670', 'pdf_path': u'/pdf/zool/v29n4/18781.pdf'})
 
     def test_pid_is_valid_pdf_request_new_site(self):
-        accesschecker = self.mocker.patch(AccessChecker)
-        accesschecker._allowed_collections()
-        self.mocker.result([u'scl', u'arg'])
-        accesschecker._acronym_to_issn_dict()
-        self.mocker.result({u'zool': u'1984-4670', u'bjmbr': u'1414-431X'})
-
-        self.mocker.replay()
-
-        ac = AccessChecker(collection='scl')
-
         request = u'GET https://www.scielo.br/pdf/bjmbr/2018.v51n11/e7704/en HTTP/1.1'
-
-        self.assertEqual(ac._is_valid_pdf_request(request), {'pdf_issn': u'1414-431X', 'pdf_path': u'/pdf/bjmbr/2018.v51n11/e7704/'})
+        self.assertEqual(self.ac._is_valid_pdf_request(request), {'pdf_issn': u'1414-431X', 'pdf_path': u'/pdf/bjmbr/2018.v51n11/e7704/'})
 
     def test_pid_is_valid_pdf_request_GET_without_domain_new_site(self):
-        accesschecker = self.mocker.patch(AccessChecker)
-        accesschecker._allowed_collections()
-        self.mocker.result([u'scl', u'arg'])
-        accesschecker._acronym_to_issn_dict()
-        self.mocker.result({u'zool': u'1984-4670', u'bjmbr': u'1414-431X'})
-
-        self.mocker.replay()
-
-        ac = AccessChecker(collection='scl')
-
         request = u'GET /pdf/bjmbr/2018.v51n11/e7704/en HTTP/1.1'
-
-        self.assertEqual(ac._is_valid_pdf_request(request), {'pdf_issn': u'1414-431X', 'pdf_path': u'/pdf/bjmbr/2018.v51n11/e7704/'})
+        self.assertEqual(self.ac._is_valid_pdf_request(request), {'pdf_issn': u'1414-431X', 'pdf_path': u'/pdf/bjmbr/2018.v51n11/e7704/'})
 
     def test_pid_is_valid_pdf_request_empty_file_path(self):
-        accesschecker = self.mocker.patch(AccessChecker)
-        accesschecker._allowed_collections()
-        self.mocker.result([u'scl', u'arg'])
-        accesschecker._acronym_to_issn_dict()
-        self.mocker.result({u'zool': u'1984-4670', u'bjmbr': u'1414-431X'})
-
-        self.mocker.replay()
-
-        ac = AccessChecker(collection='scl')
-
-        request = u''
-
-        self.assertEqual(ac._is_valid_pdf_request(request), None)
+        self.assertEqual(self.ac._is_valid_pdf_request(u''), None)
 
     def test_pid_is_valid_pdf_request_invalid_request_not_allowed_acronym(self):
-        accesschecker = self.mocker.patch(AccessChecker)
-        accesschecker._allowed_collections()
-        self.mocker.result([u'scl', u'arg'])
-        accesschecker._acronym_to_issn_dict()
-        self.mocker.result({u'zool': u'1984-4670', u'bjmbr': u'1414-431X'})
-
-        self.mocker.replay()
-
-        ac = AccessChecker(collection='scl')
-
         request = u'GET http://www.scielo.br/pdf/not_allowed_acronym/v96n2/a18v96n2.xxx HTTP/1.1'
-
-        self.assertEqual(ac._is_valid_pdf_request(request), None)
+        self.assertEqual(self.ac._is_valid_pdf_request(request), None)
 
     def test_parsed_access_valid_html_access(self):
-        accesschecker = self.mocker.patch(AccessChecker)
-        accesschecker._allowed_collections()
-        self.mocker.result([u'scl', u'arg'])
-        accesschecker._acronym_to_issn_dict()
-        self.mocker.result({u'zool': u'1984-4670', u'bjmbr': u'1414-431X'})
-
-        self.mocker.replay()
-
-        ac = AccessChecker(collection='scl')
-
         line = '187.19.211.179 - - [30/May/2013:00:01:01 -0300] "GET http://www.scielo.br/scielo.php?pid=S1414-431X2000000300007&script=sci_arttext HTTP/1.1" 200 25084 "-" "Mozilla/5.0 (compatible; MSIE 10.0; Windows NT 6.1; Trident/6.0)"'
 
         expected = {
@@ -683,36 +232,13 @@ class AccessCheckerTests(MockerTestCase):
                         'month': '05'
                     }
 
-        self.assertEqual(ac.parsed_access(line), expected)
+        self.assertEqual(self.ac.parsed_access(line), expected)
 
     def test_parsed_access_invalid_http_status_code(self):
-        accesschecker = self.mocker.patch(AccessChecker)
-        accesschecker._allowed_collections()
-        self.mocker.result([u'scl', u'arg'])
-        accesschecker._acronym_to_issn_dict()
-        self.mocker.result({u'zool': u'1984-4670', u'bjmbr': u'1414-431X'})
-
-        self.mocker.replay()
-
-        ac = AccessChecker(collection='scl')
-
         line = '187.19.211.179 - - [30/May/2013:00:01:01 -0300] "GET http://www.scielo.br/scielo.php?pid=S1414-431X2000000300007&script=sci_arttext HTTP/1.1" 404 25084 "-" "Mozilla/5.0 (compatible; MSIE 10.0; Windows NT 6.1; Trident/6.0)"'
-
-        expected = None
-
-        self.assertEqual(ac.parsed_access(line), expected)
+        self.assertEqual(self.ac.parsed_access(line), None)
 
     def test_parsed_access_valid_html_access_on_new_site(self):
-        accesschecker = self.mocker.patch(AccessChecker)
-        accesschecker._allowed_collections()
-        self.mocker.result([u'scl', u'arg'])
-        accesschecker._acronym_to_issn_dict()
-        self.mocker.result({u'zool': u'1984-4670', u'bjmbr': u'1414-431X'})
-
-        self.mocker.replay()
-
-        ac = AccessChecker(collection='scl')
-
         line = '187.19.211.179 - - [30/May/2013:00:01:01 -0300] "GET  https://www.scielo.br/article/bjmbr/2018.v51n11/e7704/en/ HTTP/1.1" 200 25084 "-" "Mozilla/5.0 (compatible; MSIE 10.0; Windows NT 6.1; Trident/6.0)"'
 
         expected = {
@@ -731,19 +257,9 @@ class AccessCheckerTests(MockerTestCase):
                         'month': '05'
                     }
 
-        self.assertEqual(ac.parsed_access(line), expected)
+        self.assertEqual(self.ac.parsed_access(line), expected)
 
     def test_parsed_access_valid_html_access_on_new_site_path_only(self):
-        accesschecker = self.mocker.patch(AccessChecker)
-        accesschecker._allowed_collections()
-        self.mocker.result([u'scl', u'arg'])
-        accesschecker._acronym_to_issn_dict()
-        self.mocker.result({u'zool': u'1984-4670', u'bjmbr': u'1414-431X'})
-
-        self.mocker.replay()
-
-        ac = AccessChecker(collection='scl')
-
         line = '187.19.211.179 - - [30/May/2013:00:01:01 -0300] "GET  /article/bjmbr/2018.v51n11/e7704/en/ HTTP/1.1" 200 25084 "-" "Mozilla/5.0 (compatible; MSIE 10.0; Windows NT 6.1; Trident/6.0)"'
 
         expected = {
@@ -761,65 +277,21 @@ class AccessCheckerTests(MockerTestCase):
                         'script': '',
                         'month': '05'
                     }
-
-        self.assertEqual(ac.parsed_access(line), expected)
+        self.assertEqual(self.ac.parsed_access(line), expected)
 
     def test_parsed_access_invalid_article_access_without_script(self):
-        accesschecker = self.mocker.patch(AccessChecker)
-        accesschecker._allowed_collections()
-        self.mocker.result([u'scl', u'arg'])
-        accesschecker._acronym_to_issn_dict()
-        self.mocker.result({u'zool': u'1984-4670', u'bjmbr': u'1414-431X'})
-
-        self.mocker.replay()
-
-        ac = AccessChecker(collection='scl')
-
         line = '187.19.211.179 - - [30/May/2013:00:01:01 -0300] "GET http://www.scielo.br/scielo.php?pid=S1414-431X2000000300007 HTTP/1.1" 200 25084 "-" "Mozilla/5.0 (compatible; MSIE 10.0; Windows NT 6.1; Trident/6.0)"'
-
-        self.assertEqual(ac.parsed_access(line), None)
+        self.assertEqual(self.ac.parsed_access(line), None)
 
     def test_parsed_access_invalid_article_access_without_pid(self):
-        accesschecker = self.mocker.patch(AccessChecker)
-        accesschecker._allowed_collections()
-        self.mocker.result([u'scl', u'arg'])
-        accesschecker._acronym_to_issn_dict()
-        self.mocker.result({u'zool': u'1984-4670', u'bjmbr': u'1414-431X'})
-
-        self.mocker.replay()
-
-        ac = AccessChecker(collection='scl')
-
         line = '187.19.211.179 - - [30/May/2013:00:01:01 -0300] "GET http://www.scielo.br/scielo.php?script=sci_arttext HTTP/1.1" 200 25084 "-" "Mozilla/5.0 (compatible; MSIE 10.0; Windows NT 6.1; Trident/6.0)"'
-
-        self.assertEqual(ac.parsed_access(line), None)
+        self.assertEqual(self.ac.parsed_access(line), None)
 
     def test_parsed_access_invalid_article_access_without_query_string(self):
-        accesschecker = self.mocker.patch(AccessChecker)
-        accesschecker._allowed_collections()
-        self.mocker.result([u'scl', u'arg'])
-        accesschecker._acronym_to_issn_dict()
-        self.mocker.result({u'zool': u'1984-4670', u'bjmbr': u'1414-431X'})
-
-        self.mocker.replay()
-
-        ac = AccessChecker(collection='scl')
-
         line = '187.19.211.179 - - [30/May/2013:00:01:01 -0300] "GET http://www.scielo.br/scielo.php HTTP/1.1" 200 25084 "-" "Mozilla/5.0 (compatible; MSIE 10.0; Windows NT 6.1; Trident/6.0)"'
-
-        self.assertEqual(ac.parsed_access(line), None)
+        self.assertEqual(self.ac.parsed_access(line), None)
 
     def test_parsed_access_valid_pdf_access_GET_string_without_domain(self):
-        accesschecker = self.mocker.patch(AccessChecker)
-        accesschecker._allowed_collections()
-        self.mocker.result([u'scl', u'arg'])
-        accesschecker._acronym_to_issn_dict()
-        self.mocker.result({u'zool': u'1984-4670', u'bjmbr': u'1414-431X'})
-
-        self.mocker.replay()
-
-        ac = AccessChecker(collection='scl')
-
         line = '66.249.73.80 - - [30/May/2013:00:01:01 -0300] "GET /pdf/bjmbr/v29n4/18781.pdf HTTP/1.1" 200 32061 "-" "Mozilla/5.0 (compatible; MSIE 10.0; Windows NT 6.1; Trident/6.0)"'
 
         expected = {
@@ -839,23 +311,11 @@ class AccessCheckerTests(MockerTestCase):
                         'script': '',
                         'pdf_path': '/pdf/bjmbr/v29n4/18781.pdf'
                     }
-
-        self.assertEqual(ac.parsed_access(line), expected)
+        self.assertEqual(self.ac.parsed_access(line), expected)
 
 
     def test_parsed_access_valid_pdf_access(self):
-        accesschecker = self.mocker.patch(AccessChecker)
-        accesschecker._allowed_collections()
-        self.mocker.result([u'scl', u'arg'])
-        accesschecker._acronym_to_issn_dict()
-        self.mocker.result({u'zool': u'1984-4670', u'bjmbr': u'1414-431X'})
-
-        self.mocker.replay()
-
-        ac = AccessChecker(collection='scl')
-
         line = '201.14.120.2 - - [30/May/2013:00:01:01 -0300] "GET http://www.scielo.br/pdf/bjmbr/v14n4/03.pdf HTTP/1.1" 200 4608 "-" "Mozilla/5.0 (compatible; MSIE 10.0; Windows NT 6.1; Trident/6.0)"'
-
         expected = {
                         'ip': '201.14.120.2',
                         'code': '/pdf/bjmbr/v14n4/03.pdf',
@@ -873,22 +333,10 @@ class AccessCheckerTests(MockerTestCase):
                         'script': '',
                         'pdf_path': '/pdf/bjmbr/v14n4/03.pdf'
                     }
-
-        self.assertEqual(ac.parsed_access(line), expected)
+        self.assertEqual(self.ac.parsed_access(line), expected)
 
     def test_parsed_access_valid_pdf_access_on_new_site(self):
-        accesschecker = self.mocker.patch(AccessChecker)
-        accesschecker._allowed_collections()
-        self.mocker.result([u'scl', u'arg'])
-        accesschecker._acronym_to_issn_dict()
-        self.mocker.result({u'zool': u'1984-4670', u'bjmbr': u'1414-431X'})
-
-        self.mocker.replay()
-
-        ac = AccessChecker(collection='scl')
-
         line = '201.14.120.2 - - [30/May/2013:00:01:01 -0300] "GET https://www.scielo.br/pdf/bjmbr/2018.v51n11/e7704/en HTTP/1.1" 200 4608 "-" "Mozilla/5.0 (compatible; MSIE 10.0; Windows NT 6.1; Trident/6.0)"'
-
         expected = {
                         'ip': '201.14.120.2',
                         'code': '/pdf/bjmbr/2018.v51n11/e7704/',
@@ -906,22 +354,10 @@ class AccessCheckerTests(MockerTestCase):
                         'script': '',
                         'pdf_path': '/pdf/bjmbr/2018.v51n11/e7704/'
                     }
-
-        self.assertEqual(ac.parsed_access(line), expected)
+        self.assertEqual(self.ac.parsed_access(line), expected)
 
     def test_parsed_access_valid_pdf_access_on_new_site_path_only(self):
-        accesschecker = self.mocker.patch(AccessChecker)
-        accesschecker._allowed_collections()
-        self.mocker.result([u'scl', u'arg'])
-        accesschecker._acronym_to_issn_dict()
-        self.mocker.result({u'zool': u'1984-4670', u'bjmbr': u'1414-431X'})
-
-        self.mocker.replay()
-
-        ac = AccessChecker(collection='scl')
-
         line = '201.14.120.2 - - [30/May/2013:00:01:01 -0300] "GET /pdf/bjmbr/2018.v51n11/e7704/en HTTP/1.1" 200 4608 "-" "Mozilla/5.0 (compatible; MSIE 10.0; Windows NT 6.1; Trident/6.0)"'
-
         expected = {
                         'ip': '201.14.120.2',
                         'code': '/pdf/bjmbr/2018.v51n11/e7704/',
@@ -939,35 +375,12 @@ class AccessCheckerTests(MockerTestCase):
                         'script': '',
                         'pdf_path': '/pdf/bjmbr/2018.v51n11/e7704/'
                     }
-
-        self.assertEqual(ac.parsed_access(line), expected)
+        self.assertEqual(self.ac.parsed_access(line), expected)
 
     def test_parsed_access_valid_pdf_with_not_allowed_acronym(self):
-        accesschecker = self.mocker.patch(AccessChecker)
-        accesschecker._allowed_collections()
-        self.mocker.result([u'scl', u'arg'])
-        accesschecker._acronym_to_issn_dict()
-        self.mocker.result({u'zool': u'1984-4670', u'bjmbr': u'1414-431X'})
-
-        self.mocker.replay()
-
-        ac = AccessChecker(collection='scl')
-
         line = '201.14.120.2 - - [30/May/2013:00:01:01 -0300] "GET http://www.scielo.br/pdf/not_allowed_acronym/v14n4/03.pdf HTTP/1.1" 206 4608 "-" "Mozilla/5.0 (compatible; MSIE 10.0; Windows NT 6.1; Trident/6.0)"'
-
-        self.assertEqual(ac.parsed_access(line), None)
+        self.assertEqual(self.ac.parsed_access(line), None)
 
     def test_parsed_access_valid_pdf_with_any_different_access(self):
-        accesschecker = self.mocker.patch(AccessChecker)
-        accesschecker._allowed_collections()
-        self.mocker.result([u'scl', u'arg'])
-        accesschecker._acronym_to_issn_dict()
-        self.mocker.result({u'zool': u'1984-4670', u'bjmbr': u'1414-431X'})
-
-        self.mocker.replay()
-
-        ac = AccessChecker(collection='scl')
-
         line = '177.191.212.233 - - [30/May/2013:00:01:01 -0300] "GET http://www.scielo.br/img/pt/author.gif HTTP/1.1" 304 0 "http://www.scielo.br/scielo.php?script=sci_serial&pid=1415-4757&nrm=iso&rep=&lng=pt" "Mozilla/5.0 (Windows NT 5.1) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/27.0.1453.94 Safari/537.36"'
-
-        self.assertEqual(ac.parsed_access(line), None)
+        self.assertEqual(self.ac.parsed_access(line), None)


### PR DESCRIPTION
#### O que esse PR faz?
Adiciona suporte ao registro de acessos a partir das seguintes URLs, presentes no OPAC:

* `/j/abdc/a/MYJY5Rgw5gc7mBpqYzBCVJR`
* `/j/abdc/a/MYJY5Rgw5gc7mBpqYzBCVJR?format=html`
* `/j/abdc/a/MYJY5Rgw5gc7mBpqYzBCVJR?format=pdf`

#### Onde a revisão poderia começar?
Sugiro uma revisão commit a commit.

#### Como este poderia ser testado manualmente?

Vocês podem simular o _parsing_ de alguns logs, como por exemplo:

```python
from logger import accesschecker

ac = accesschecker.AccessChecker(collection="spa", counter_compliant=True)

lines = [
    '132.255.240.129 - - [24/May/2020:00:00:03 -0300] "GET /j/ress/a/F5Zr9TrzfmMgz9kvGZL3rZB HTTP/2.0" 200 18520 "-" "Mozilla/5.0 (Windows NT 10.0; ) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/81.0.4044.138 Safari/537.36"\n',
    '132.255.240.129 - - [24/May/2020:00:00:03 -0300] "GET /j/ress/a/F5Zr9TrzfmMgz9kvGZL3rZB?format=html HTTP/2.0" 200 18520 "-" "Mozilla/5.0 (Windows NT 10.0; ) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/81.0.4044.138 Safari/537.36"\n',
    '132.255.240.129 - - [24/May/2020:00:00:03 -0300] "GET /j/ress/a/F5Zr9TrzfmMgz9kvGZL3rZB?format=pdf HTTP/2.0" 200 18520 "-" "Mozilla/5.0 (Windows NT 10.0; ) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/81.0.4044.138 Safari/537.36"\n',
]

for i, line in enumerate(lines, 1):
    print("Linha %s: %s" % (i, ac.parsed_access(line.encode("utf-8"))))
```

O exemplo acima depende de estar conectado na VPN.

#### Algum cenário de contexto que queira dar?
Ainda em tempo, é importante notar que o Ratchet registra apenas acessos às páginas do documento, PDF, ePDF (descontinuado) e resumo. Este PR adiciona suporte aos 2 primeiros.

### Screenshots
Quando aplicável e se fizer possível adicione screenshots que remetem a situação gráfica do problema que o pull request resolve.

#### Quais são tickets relevantes?
#46 

### Referências
n/a
