### PR TITLE
Fixa a versão das dependências para instalação com setup.py e requirements.txt

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -12,7 +12,7 @@ kombu==3.0.37
 legendarium==2.0.2
 pathtools==0.1.2
 ply==3.11
-pymongo==3.7.2
+pymongo==2.9
 pytz==2018.5
 PyYAML==3.13
 requests==2.19.1

--- a/setup.py
+++ b/setup.py
@@ -13,12 +13,12 @@ with open(os.path.join(here, 'CHANGES.rst')) as f:
     CHANGES = f.read()
 
 install_requires = [
-    'requests>=2.11.1',
-    'apachelog>=1.0',
-    'pymongo>=2.8',
-    'celery>=3.1.18',
-    'watchdog>=0.8.3',
-    'articlemetaapi',
+    'requests==2.19.1',
+    'apachelog==1.0',
+    'pymongo==2.9',
+    'celery==3.1.18',
+    'watchdog==0.8.3',
+    'articlemetaapi==1.26.5',
 ]
 
 tests_require = [


### PR DESCRIPTION
#### O que esse PR faz?

Fixa a versão das dependências para instalação com setup.py e requirements.txt

#### Onde a revisão poderia começar?

Verificando os arquivos **setup.py** e **requirements.txt**

#### Como este poderia ser testado manualmente?

Realizando a instalação e rodando o processamento utilizando os seguintes comandos: 

Previamente rodar a instalação com **setup.py** 

```shell
export LOGGER_SETTINGS_FILE=/etc/scieloapps/logger.ini

celery -A logger.tasks worker --loglevel=info -c2 --maxtasksperchild=2 > /var/log/logger.log

logger_inspector -s /var/www/ftp_ratchet_scielo_org/  -l DEBUG -c /var/BKP_FTP/ > /var/log/logger_inspector.log

```
#### Algum cenário de contexto que queira dar?

Está sendo considerado as versões instaladas nos servidores de processamento e atualmente rodando sem erros de versões.

### Screenshots
Quando aplicável e se fizer possível adicione screenshots que remetem a situação gráfica do problema que o pull request resolve.

#### Quais são tickets relevantes?
N/A

### Referências
N/A
